### PR TITLE
Add LockSuitLog API method to disable SuitLog

### DIFF
--- a/SuitLog/API/ISuitLogAPI.cs
+++ b/SuitLog/API/ISuitLogAPI.cs
@@ -26,4 +26,14 @@ public interface ISuitLogAPI
     public void ItemListDescriptionFieldClose(MonoBehaviour itemList);
     public List<ShipLogEntryListItem> ItemListGetItemsUI(MonoBehaviour itemList);
     public int ItemListGetIndexUI(MonoBehaviour itemList, int index);
+    /// <summary>
+    /// Disables SuitLog from opening. In case there are multiple calls to LockSuitLog, it stays disabled until all callers have called UnlockedSuitLog.
+    /// </summary>
+    /// <param name="caller">A reference to calling object. Pass the same object to UnlockSuitLog.</param>
+    public void LockSuitLog(object caller);
+    /// <summary>
+    /// Tries to re-enable SuitLog. In case there were multiple calls to LockSuitLog, it stays disabled until all callers have called UnlockedSuitLog.
+    /// </summary>
+    /// <param name="caller">A reference to calling object. Pass the same object you passed to LockSuitLog.</param>
+    public void UnlockSuitLog(object caller);
 }

--- a/SuitLog/API/SuitLogAPI.cs
+++ b/SuitLog/API/SuitLogAPI.cs
@@ -96,4 +96,14 @@ public class SuitLogAPI : ISuitLogAPI
     {
         return ((SuitLogItemList)itemList).GetIndexUI(index);
     }
+
+    public void LockSuitLog(object caller)
+    {
+        SuitLog.Instance.LockSuitLog(caller);
+    }
+
+    public void UnlockSuitLog(object caller)
+    {
+        SuitLog.Instance.UnlockSuitLog(caller);
+    }
 }

--- a/SuitLog/SuitLog.cs
+++ b/SuitLog/SuitLog.cs
@@ -41,6 +41,8 @@ namespace SuitLog
         internal const float OpenAnimationDuration = 0.13f;
         internal const float CloseAnimationDuration = 0.3f;
 
+        private HashSet<object> _locks = new();
+
         private void Start()
         {
             Instance = this;
@@ -246,6 +248,7 @@ namespace SuitLog
                    !_toolModeSwapper._probeLauncher.IsEquipped() &&
                    !_toolModeSwapper._translator.IsEquipped() &&
                    !holds_tool &&
+                   _locks.Count == 0 &&
                    // Otherwise the repair prompt will appear in suit log and conflict with view entries
                    _toolModeSwapper._firstPersonManipulator._focusedRepairReceiver == null;
         }
@@ -381,6 +384,16 @@ namespace SuitLog
                 // (going to Menu is also possible in preflight list but Suit Log should be closed when doing that)
                 Instance.CloseSuitLog();
             }
+        }
+
+        public void LockSuitLog(object caller)
+        {
+            _locks.Add(caller);
+        }
+
+        public void UnlockSuitLog(object caller)
+        {
+            _locks.Remove(caller);
         }
     }
 }


### PR DESCRIPTION
Implements #9 
Changed the name to LockSuitLog/UnlockSuitLog to better reflect the behavior: you can place multiple locks on Suit Log, and it won't open until all the locks are lifted.